### PR TITLE
Refactor getting_started messages into toolchain

### DIFF
--- a/.bluemix/locales_getting_started.yml
+++ b/.bluemix/locales_getting_started.yml
@@ -1,0 +1,29 @@
+---
+root:
+  $ref: ./nls/messages_getting_started.yml
+de:
+  $ref: ./nls/messages_getting_started_de.yml
+en-AA:
+  $ref: ./nls/messages_getting_started_en_AA.yml
+en-RR:
+  $ref: ./nls/messages_getting_started_en_RR.yml
+en-ZZ:
+  $ref: ./nls/messages_getting_started_en_ZZ.yml
+es:
+  $ref: ./nls/messages_getting_started_es.yml
+fr:
+  $ref: ./nls/messages_getting_started_fr.yml
+it:
+  $ref: ./nls/messages_getting_started_it.yml
+ja:
+  $ref: ./nls/messages_getting_started_ja.yml
+ko:
+  $ref: ./nls/messages_getting_started_ko.yml
+pt-BR:
+  $ref: ./nls/messages_getting_started_pt_BR.yml
+zh:
+  $ref: ./nls/messages_getting_started_zh.yml
+zh-HK:
+  $ref: ./nls/messages_getting_started_zh_HK.yml
+zh-TW:
+  $ref: ./nls/messages_getting_started_zh_TW.yml

--- a/.bluemix/nls/messages.yml
+++ b/.bluemix/nls/messages.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Simple Cloud Foundry toolchain (v2)"
 template.description: "With this toolchain, you can develop and deploy a Cloud Foundry application. By default, the toolchain clones a sample Node.js “Hello World” app into an IBM hosted Git repo, which you can then modify.  This toolchain is preconfigured for continuous delivery, source control, issue tracking, and online editing.\n\nThe toolchain uses tools that are part of the Continuous Delivery service.  If an instance of that service isn’t already in your organization, when you click **Create**, it is automatically added at no cost to you. For more information and terms, see the [Bluemix catalog](https://console.ng.bluemix.net/catalog/services/continuous-delivery/).\n\nTo get started, click **Create**."
-template.gettingStarted: "**Your toolchain is ready!**\n**Quick start:** Commit a change to the Git repo to trigger a new build and deployment. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2?task=2) for this toolchain."
 deploy.title: "Sample Deploy Stage"
 deploy.description: "sample toolchain"
 deploy.longDescription: "The Delivery Pipeline automates continuous deployment."

--- a/.bluemix/nls/messages_de.yml
+++ b/.bluemix/nls/messages_de.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Einfache Cloud Foundry-Toolchain (v2)"
 template.description: "Mit dieser Toolchain können Sie eine Cloud Foundry-Anwendung entwickeln und bereitstellen. Die Toolchain klont standardmäßig eine Node.js-Beispiel-App “Hello World” in einem von IBM gehosteteten Git-Repository, die Sie anschließend ändern können. Diese Toolchain ist für die kontinuierliche Bereitstellung, Quellcodeverwaltung, Problemverfolgung und Onlinebearbeitung vorkonfiguriert.\n\nDiese Toolchain verwendet Tools, die Teil des Continuous Delivery-Service sind. Wenn sich noch keine Instanz dieses Service in Ihrer Organisation befindet, wird sie automatisch hinzugefügt, wenn Sie auf **Erstellen** klicken, ohne dass für Sie Kosten anfallen. Weitere Informationen und Bedingungen finden Sie im [Bluemix-Katalog](https://console.ng.bluemix.net/catalog/services/continuous-delivery/).\n\nKlicken Sie auf **Erstellen**, um zu beginnen."
-template.gettingStarted: "**Ihre Toolchain steht bereit!**\n**Schnelleinstieg:** Schreiben Sie eine Änderung im Git-Repository fest, um einen neuen Build und eine neue Bereitstellung auszulösen. Schrittweise Anleitungen bietet das [Lernprogramm](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2) für diese Toolchain. "
 deploy.title: "Beispielbereitstellungsphase"
 deploy.description: "Beispieltoolchain"
 deploy.longDescription: "Mit Delivery Pipeline wird die kontinuierliche Bereitstellung automatisiert."

--- a/.bluemix/nls/messages_en_AA.yml
+++ b/.bluemix/nls/messages_en_AA.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "1:Simple Cloud Foundry toolchain (v2)"
 template.description: "2:With this toolchain, you can develop and deploy a Cloud Foundry application. By default, the toolchain clones a sample Node.js “Hello World” app into an IBM hosted Git repo, which you can then modify.  This toolchain is preconfigured for continuous delivery, source control, issue tracking, and online editing.\n\nThe toolchain uses tools that are part of the Continuous Delivery service.  If an instance of that service isn’t already in your organization, when you click **Create**, it is automatically added at no cost to you. For more information and terms, see the [Bluemix catalog](https://console.ng.bluemix.net/catalog/services/continuous-delivery/).\n\nTo get started, click **Create**."
-template.gettingStarted: "3:**Your toolchain is ready!**\n**Quick start:** Commit a change to the Git repo to trigger a new build and deployment. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2) for this toolchain."
 deploy.title: "4:Sample Deploy Stage"
 deploy.description: "5:sample toolchain"
 deploy.longDescription: "6:The Delivery Pipeline automates continuous deployment."

--- a/.bluemix/nls/messages_en_RR.yml
+++ b/.bluemix/nls/messages_en_RR.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Simple Cloud Foundry toolchain (v2)~otc-ui884"
 template.description: "With this toolchain, you can develop and deploy a Cloud Foundry application. By default, the toolchain clones a sample Node.js “Hello World” app into an IBM hosted Git repo, which you can then modify.  This toolchain is preconfigured for continuous delivery, source control, issue tracking, and online editing.\n\nThe toolchain uses tools that are part of the Continuous Delivery service.  If an instance of that service isn’t already in your organization, when you click **Create**, it is automatically added at no cost to you. For more information and terms, see the [Bluemix catalog](https://console.ng.bluemix.net/catalog/services/continuous-delivery/).\n\nTo get started, click **Create**.~otc-ui885"
-template.gettingStarted: "**Your toolchain is ready!**\n**Quick start:** Commit a change to the Git repo to trigger a new build and deployment. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2) for this toolchain.~otc-ui886"
 deploy.title: "Sample Deploy Stage~otc-ui887"
 deploy.description: "sample toolchain~otc-ui888"
 deploy.longDescription: "The Delivery Pipeline automates continuous deployment.~otc-ui889"

--- a/.bluemix/nls/messages_en_ZZ.yml
+++ b/.bluemix/nls/messages_en_ZZ.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "[G'Ｓｉｍｐｌｅ Ｃｌｏｕd Foundry toolchain (v2)ฏูİı｜]"
 template.description: "[G'Ｗｉｔｈ ｔｈｉｓ ｔｏｏｌｃｈａｉｎ, ｙｏｕ ｃａｎ ｄｅｖｅｌｏｐ ａｎｄ ｄｅｐｌｏｙ ａ Ｃｌｏｕｄ Ｆｏｕｎｄｒｙ ａｐｐｌｉｃａｔｉｏｎ. Ｂｙ ｄｅｆａｕｌｔ, ｔｈｅ ｔｏｏｌｃｈａｉｎ ｃｌｏｎｅｓ ａ ｓａｍｐｌｅ Ｎｏｄｅ.ｊｓ “Ｈｅｌｌｏ Ｗｏｒｌｄ” ａｐｐ ｉｎｔｏ ａｎ ＩＢＭ ｈｏｓｔｅｄ Ｇｉｔ ｒｅｐｏ, ｗｈｉｃｈ ｙｏｕ ｃａｎ ｔｈｅｎ ｍｏｄｉｆｙ.  Ｔｈｉｓ ｔｏｏｌｃｈａｉｎ ｉｓ ｐｒｅｃｏｎｆｉｇｕｒｅｄ ｆｏｒ ｃｏｎｔｉｎｕｏus delivery, source control, issue tracking, and online editing.\n\nThe toolchain uses tools that are part of the Continuous Delivery service.  If an instance of that service isn’t already in your organization, when you click **Create**, it is automatically added at no cost to you. For more information and terms, see the [Bluemix catalog](https://console.ng.bluemix.net/catalog/services/continuous-delivery/).\n\nTo get started, click **Create**.ฏูİı｜]"
-template.gettingStarted: "[G'**Ｙｏｕｒ ｔｏｏｌｃｈａｉｎ ｉｓ ｒｅａｄｙ!**\n**Ｑｕｉｃｋ ｓｔａｒｔ:** Ｃｏｍｍｉｔ ａ ｃｈａｎｇｅ ｔｏ ｔｈｅ Ｇｉｔ ｒｅｐｏ ｔｏ ｔｒｉｇｇｅｒ ａ ｎｅw build and deployment. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2) for this toolchain.ฏูİı｜]"
 deploy.title: "[G'Ｓａｍｐｌｅ Deploy Stageฏูİı｜]"
 deploy.description: "[G'ｓａｍｐｌe toolchainฏูİı｜]"
 deploy.longDescription: "[G'Ｔｈｅ Ｄｅｌｉｖｅｒｙ Ｐipeline automates continuous deployment.ฏูİı｜]"

--- a/.bluemix/nls/messages_es.yml
+++ b/.bluemix/nls/messages_es.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Cadena de herramientas simple de Cloud Foundry (v2)"
 template.description: "Con esta cadena de herramientas, puede desarrollar y desplegar una aplicación Cloud Foundry. De forma predeterminada, la cadena de herramientas clona una app Node.js \"Hello World\" en un repositorio Git alojado por IBM, que luego puede modificar. Esta cadena de herramientas está preconfigurada para la entrega continua, el control de origen, el seguimiento de problemas y la edición en línea.\n\nLa cadena de herramientas utiliza herramientas que forman parte del servicio de Continuous Delivery. Si aún no hay una instancia de dicho servicio en la organización, cuando pulse **Crear**, se añadirá automáticamente sin coste alguno para usted. Para obtener más información y los términos consulte el [catálogo Bluemix](https://console.ng.bluemix.net/catalog/services/continuous-delivery/).\n\nPara comenzar, pulse **Crear**."
-template.gettingStarted: "**¡Su cadena de herramientas está lista!**\n**Inicio rápido:** Confirmar un cambio en el repositorio Git para desencadenar una nueva compilación y despliegue. Para obtener instrucciones detalladas paso a paso, consulte la [guía de aprendizaje](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2) para esta cadena de herramientas. "
 deploy.title: "Sample Deploy Stage"
 deploy.description: "cadena de herramientas de ejemplo"
 deploy.longDescription: "Delivery Pipeline automatiza el despliegue continuo."

--- a/.bluemix/nls/messages_fr.yml
+++ b/.bluemix/nls/messages_fr.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Chaîne d'outils Cloud Foundry simple (v2)"
 template.description: "Cette chaîne d'outils vous permet de développer et de déployer une application Cloud Foundry. Par défaut, la chaîne d'outils clone une application exemple Node.js \"Hello World\" dans un référentiel Git hébergé par IBM, que vous pouvez ensuite modifier. Cette chaîne d'outils est préconfigurée pour la distribution continue, le contrôle des sources, le suivi des problèmes et l'édition en ligne.\n\nLa chaîne d'outils utilise des outils qui font partie du service Continuous Delivery. Si aucune instance de ce service n'existe dans votre organisation, elle est automatiquement ajoutée, sans aucun frais, lorsque vous cliquez sur **Créer**. Pour plus d'informations et pour obtenir les dispositions applicables, consultez le [catalogue Bluemix](https://console.ng.bluemix.net/catalog/services/continuous-delivery/).\n\nPour commencer, cliquez sur **Créer**."
-template.gettingStarted: "**Votre chaîne d'outils est prête !**\n**Démarrage rapide :** validez une modification dans le référentiel Git afin de déclencher une nouvelle génération et un nouveau déploiement. Pour obtenir des instructions étape par étape, reportez-vous au [tutoriel](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2) relatif à cette chaîne d'outils. "
 deploy.title: "Etape de déploiement exemple"
 deploy.description: "Chaîne d'outils exemple"
 deploy.longDescription: "Delivery Pipeline automatise le déploiement en continu."

--- a/.bluemix/nls/messages_getting_started.yml
+++ b/.bluemix/nls/messages_getting_started.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**Your toolchain is ready!**\n**Quick start:** Commit a change to the Git repo to trigger a new build and deployment. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2?task=2) for this toolchain."

--- a/.bluemix/nls/messages_getting_started_de.yml
+++ b/.bluemix/nls/messages_getting_started_de.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**Ihre Toolchain steht bereit!**\n**Schnelleinstieg:** Schreiben Sie eine Änderung im Git-Repository fest, um einen neuen Build und eine neue Bereitstellung auszulösen. Schrittweise Anleitungen bietet das [Lernprogramm](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2) für diese Toolchain. "

--- a/.bluemix/nls/messages_getting_started_en_AA.yml
+++ b/.bluemix/nls/messages_getting_started_en_AA.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "3:**Your toolchain is ready!**\n**Quick start:** Commit a change to the Git repo to trigger a new build and deployment. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2) for this toolchain."

--- a/.bluemix/nls/messages_getting_started_en_RR.yml
+++ b/.bluemix/nls/messages_getting_started_en_RR.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**Your toolchain is ready!**\n**Quick start:** Commit a change to the Git repo to trigger a new build and deployment. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2) for this toolchain.~otc-ui886"

--- a/.bluemix/nls/messages_getting_started_en_ZZ.yml
+++ b/.bluemix/nls/messages_getting_started_en_ZZ.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "[G'**Ｙｏｕｒ ｔｏｏｌｃｈａｉｎ ｉｓ ｒｅａｄｙ!**\n**Ｑｕｉｃｋ ｓｔａｒｔ:** Ｃｏｍｍｉｔ ａ ｃｈａｎｇｅ ｔｏ ｔｈｅ Ｇｉｔ ｒｅｐｏ ｔｏ ｔｒｉｇｇｅｒ ａ ｎｅw build and deployment. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2) for this toolchain.ฏูİı｜]"

--- a/.bluemix/nls/messages_getting_started_es.yml
+++ b/.bluemix/nls/messages_getting_started_es.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**¡Su cadena de herramientas está lista!**\n**Inicio rápido:** Confirmar un cambio en el repositorio Git para desencadenar una nueva compilación y despliegue. Para obtener instrucciones detalladas paso a paso, consulte la [guía de aprendizaje](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2) para esta cadena de herramientas. "

--- a/.bluemix/nls/messages_getting_started_fr.yml
+++ b/.bluemix/nls/messages_getting_started_fr.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**Votre chaîne d'outils est prête !**\n**Démarrage rapide :** validez une modification dans le référentiel Git afin de déclencher une nouvelle génération et un nouveau déploiement. Pour obtenir des instructions étape par étape, reportez-vous au [tutoriel](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2) relatif à cette chaîne d'outils. "

--- a/.bluemix/nls/messages_getting_started_it.yml
+++ b/.bluemix/nls/messages_getting_started_it.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**La toolchain è pronta!**\n**Avvio rapido:** Eseguire il commit di una modifica al repository Git per attivare una nuova build e distribuzione.Per le sitruzioni passo dopo passo, consultare il [supporto didattico](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2) per questa toolchain."

--- a/.bluemix/nls/messages_getting_started_ja.yml
+++ b/.bluemix/nls/messages_getting_started_ja.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**ツールチェーンの準備ができました。**\n**クイック・スタート:** Git リポジトリーに対する変更をコミットし、新しいビルドおよびデプロイメントをトリガーしてください。ステップバイステップの説明については、このツールチェーンの[チュートリアル](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2)を参照してください。"

--- a/.bluemix/nls/messages_getting_started_ko.yml
+++ b/.bluemix/nls/messages_getting_started_ko.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**도구 체인이 준비되었습니다!**\n**빠른 시작:** Git 저장소에 변경사항을 커미트하여 새 빌드와 배치를 트리거하십시오. 단계별 지시사항은 이 도구 체인의 [튜토리얼](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2)을 참조하십시오."

--- a/.bluemix/nls/messages_getting_started_pt_BR.yml
+++ b/.bluemix/nls/messages_getting_started_pt_BR.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**Sua cadeia de ferramentas está pronta!**\n**Iniciação rápida:** Confirme uma mudança no repositório Git para acionar uma nova compilação e implementação. Para obter instruções passo a passo, consulte o [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2) para esta cadeia de ferramentas."

--- a/.bluemix/nls/messages_getting_started_zh.yml
+++ b/.bluemix/nls/messages_getting_started_zh.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**工具链已就绪！**\n**快速启动：** 将更改落实到 Git 存储库以触发新的构建和部署。有关逐步指示信息，请参阅此工具链的[教程](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2)。"

--- a/.bluemix/nls/messages_getting_started_zh_HK.yml
+++ b/.bluemix/nls/messages_getting_started_zh_HK.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**您的工具鏈已備妥！**\n**快速入門：** 確定 Git 儲存庫的變更，以觸發新的建置及部署。如需逐步指示，請參閱此工具鏈的 [指導教學](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2)。"

--- a/.bluemix/nls/messages_getting_started_zh_TW.yml
+++ b/.bluemix/nls/messages_getting_started_zh_TW.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**您的工具鏈已備妥！**\n**快速入門：** 確定 Git 儲存庫的變更，以觸發新的建置及部署。如需逐步指示，請參閱此工具鏈的 [指導教學](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2)。"

--- a/.bluemix/nls/messages_it.yml
+++ b/.bluemix/nls/messages_it.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Toolchain Cloud Foundry semplice (v2)"
 template.description: "Utilizzando questa toolchain, è possibile sviluppare e distribuire un'applicazione Cloud Foundry. Per impostazione predefinita, la toolchain clona un'app “Hello World” Node.js di esempio in un repository Git ospitato da IBM che è possibile quindi modificare.Questa toolchain è preconfigurata per la distribuzione continua, il controllo origine, la traccia dei problemi e la modifica online.\n\nLa toolchain utilizza gli strumenti che fanno parte del servizio Continuous Delivery. Se nella propria organizzazione non è già presente un'istanza di tale servizio, quando si seleziona **Crea**, viene automaticamente aggiunta gratuitamente. Per ulteriori informazioni e per i termini, consultare il [catalogo Bluemix](https://console.ng.bluemix.net/catalog/services/continuous-delivery/).\n\nPer iniziare, fare clic su **Crea**."
-template.gettingStarted: "**La toolchain è pronta!**\n**Avvio rapido:** Eseguire il commit di una modifica al repository Git per attivare una nuova build e distribuzione.Per le sitruzioni passo dopo passo, consultare il [supporto didattico](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2) per questa toolchain."
 deploy.title: "Stage di distribuzione di esempio"
 deploy.description: "toolchain di esempio"
 deploy.longDescription: "Delivery Pipeline automatizza la distribuzione continua."

--- a/.bluemix/nls/messages_ja.yml
+++ b/.bluemix/nls/messages_ja.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Simple Cloud Foundry ツールチェーン (v2)"
 template.description: "このツールチェーンを使用して、Cloud Foundry アプリケーションを開発およびデプロイすることができます。デフォルトでは、このツールチェーンはサンプル Node.js「Hello World」アプリのクローンを、IBM がホストする Git リポジトリーに作成します。その後で、そのクローンを変更できます。このツールチェーンは、継続的デリバリー、ソース管理、問題のトラッキング、およびオンライン編集用に事前構成されています。\n\nこのツールチェーンは、Continuous Delivery サービスに含まれるツールを使用します。そのサービスのインスタンスが自分の組織にまだない場合は、**「作成」**をクリックすると、無料でそのインスタンスが自動的に追加されます。詳細および条件については、[Bluemix カタログ](https://console.ng.bluemix.net/catalog/services/continuous-delivery/)を参照してください。\n\n開始するには、**「作成」**をクリックします。"
-template.gettingStarted: "**ツールチェーンの準備ができました。**\n**クイック・スタート:** Git リポジトリーに対する変更をコミットし、新しいビルドおよびデプロイメントをトリガーしてください。ステップバイステップの説明については、このツールチェーンの[チュートリアル](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2)を参照してください。"
 deploy.title: "サンプルのデプロイ・ステージ"
 deploy.description: "サンプル・ツールチェーン"
 deploy.longDescription: "Delivery Pipeline は、継続的デプロイメントを自動化します。"

--- a/.bluemix/nls/messages_ko.yml
+++ b/.bluemix/nls/messages_ko.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "단순 Cloud Foundry 도구 체인(v2)"
 template.description: "이 도구 체인을 사용하면 Cloud Foundry 애플리케이션을 개발하고 배치할 수 있습니다. 기본적으로 도구 체인은 샘플 Node.js “Hello World” 앱을 IBM에서 호스팅하는 Git 저장소에 복제하며 이후 사용자는 이 앱을 수정할 수 있습니다. 이 도구 체인은 지속적 딜리버리, 소스 제어, 문제 추적 및 온라인 편집을 위해 사전 구성되어 있습니다.\n\n도구 체인에서는 Continuous Delivery 서비스의 일부인 도구를 사용합니다. 해당 서비스의 인스턴스가 아직 조직에 없는 경우, **작성**을 클릭하면 별도의 비용 없이 인스턴스가 자동으로 추가됩니다. 자세한 정보와 용어는 [Bluemix 카탈로그](https://console.ng.bluemix.net/catalog/services/continuous-delivery/)를 참조하십시오.\n\n계속하려면 **작성**을 클릭하십시오."
-template.gettingStarted: "**도구 체인이 준비되었습니다!**\n**빠른 시작:** Git 저장소에 변경사항을 커미트하여 새 빌드와 배치를 트리거하십시오. 단계별 지시사항은 이 도구 체인의 [튜토리얼](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2)을 참조하십시오."
 deploy.title: "샘플 배치 단계"
 deploy.description: "샘플 도구 체인"
 deploy.longDescription: "Delivery Pipeline은 지속적 배치를 자동화합니다."

--- a/.bluemix/nls/messages_pt_BR.yml
+++ b/.bluemix/nls/messages_pt_BR.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Cadeia de ferramentas simples do Cloud Foundry (v2)"
 template.description: "Com esta cadeia de ferramentas, é possível desenvolver e implementar um aplicativo Cloud Foundry. Por padrão, a cadeia de ferramentas clona um app de amostra Node.js “Hello World” em um repositório Git hospedado pela IBM, que depois você pode modificar. Esta cadeia de ferramentas é pré-configurada para entrega contínua, controle de fonte, rastreamento de problemas e edição on-line.\n\nA cadeia de ferramentas usa ferramentas que fazem parte do serviço Continuous Delivery. Se uma instância desse serviço não estiver em sua organização ainda, ao clicar em **Criar**, ela será incluída automaticamente sem encargos para você. Para obter mais informações e termos, consulte o [catálogo do Bluemix](https://console.ng.bluemix.net/catalog/services/continuous-delivery/).\n\nPara iniciar, clique em **Criar**."
-template.gettingStarted: "**Sua cadeia de ferramentas está pronta!**\n**Iniciação rápida:** Confirme uma mudança no repositório Git para acionar uma nova compilação e implementação. Para obter instruções passo a passo, consulte o [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2) para esta cadeia de ferramentas."
 deploy.title: "Estágio de Implementação de Amostra"
 deploy.description: "cadeia de ferramentas de amostra"
 deploy.longDescription: "O Delivery Pipeline automatiza a implementação contínua."

--- a/.bluemix/nls/messages_zh.yml
+++ b/.bluemix/nls/messages_zh.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "简单 Cloud Foundry 工具链 (V2)"
 template.description: "使用此工具链，可开发和部署 Cloud Foundry 应用程序。缺省情况下，此工具链会将样本 Node.js“Hello World”应用程序克隆到 IBM 托管的 Git 存储库中，然后可以对其进行修改。预先配置了此工具链，以进行持续交付、源代码控制、问题跟踪以及联机编辑。\n\n此工具链使用 Continuous Delivery 服务中的工具。如果您组织中没有该服务的实例，当您单击**创建**时，会免费为您自动添加该服务实例。有关更多信息和术语，请参阅 [Bluemix 目录](https://console.ng.bluemix.net/catalog/services/continuous-delivery/)。\n\n单击**创建**以开始。"
-template.gettingStarted: "**工具链已就绪！**\n**快速启动：** 将更改落实到 Git 存储库以触发新的构建和部署。有关逐步指示信息，请参阅此工具链的[教程](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2)。"
 deploy.title: "样本部署暂存区"
 deploy.description: "样本工具链"
 deploy.longDescription: "Delivery Pipeline 自动执行持续部署。"

--- a/.bluemix/nls/messages_zh_HK.yml
+++ b/.bluemix/nls/messages_zh_HK.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "簡式 Cloud Foundry 工具鏈（第 2 版）"
 template.description: "使用此工具鏈，您可以開發及部署 Cloud Foundry 應用程式。依預設，工具鏈會將範例 Node.js \"Hello World\" 應用程式複製到 IBM 管理的 Git 儲存庫中，然後您可以進行修改。此工具鏈已預先配置為持續交付，以進行來源控制、問題追蹤以及線上編輯。\n\n此工具鏈會使用屬於 Continuous Delivery 服務的工具。當您按一下 **建立** 時，如果組織中尚未具有該服務的實例，則將自動新增實例而不收取費用。如需相關資訊及術語，請參閱 [Bluemix 型錄](https://console.ng.bluemix.net/catalog/services/continuous-delivery/)。\n\n若要開始，請按一下**建立**。"
-template.gettingStarted: "**您的工具鏈已備妥！**\n**快速入門：** 確定 Git 儲存庫的變更，以觸發新的建置及部署。如需逐步指示，請參閱此工具鏈的 [指導教學](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2)。"
 deploy.title: "範例服務部署暫置"
 deploy.description: "範例工具鏈"
 deploy.longDescription: "Delivery Pipeline 會自動執行連續部署。"

--- a/.bluemix/nls/messages_zh_TW.yml
+++ b/.bluemix/nls/messages_zh_TW.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "簡式 Cloud Foundry 工具鏈（第 2 版）"
 template.description: "使用此工具鏈，您可以開發及部署 Cloud Foundry 應用程式。依預設，工具鏈會將範例 Node.js \"Hello World\" 應用程式複製到 IBM 管理的 Git 儲存庫中，然後您可以進行修改。此工具鏈已預先配置為持續交付，以進行來源控制、問題追蹤以及線上編輯。\n\n此工具鏈會使用屬於 Continuous Delivery 服務的工具。當您按一下 **建立** 時，如果組織中尚未具有該服務的實例，則將自動新增實例而不收取費用。如需相關資訊及術語，請參閱 [Bluemix 型錄](https://console.ng.bluemix.net/catalog/services/continuous-delivery/)。\n\n若要開始，請按一下**建立**。"
-template.gettingStarted: "**您的工具鏈已備妥！**\n**快速入門：** 確定 Git 儲存庫的變更，以觸發新的建置及部署。如需逐步指示，請參閱此工具鏈的 [指導教學](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_cfv2)。"
 deploy.title: "範例服務部署暫置"
 deploy.description: "範例工具鏈"
 deploy.longDescription: "Delivery Pipeline 會自動執行連續部署。"

--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -20,7 +20,7 @@ toolchain:
   name: 'simple-toolchain-{{timestamp}}'
   template:
     getting_started:
-      $ref: "#/messages/template.gettingStarted"
+      $ref: locales_getting_started.yml
 services:
   sample-repo:
     service_id: hostedgit


### PR DESCRIPTION
Store all translations of 'getting started' message in the `toolchain.template` field.
This allows the UI to choose which string to display according to the browser locale.
