### PR TITLE
added quotes to fix pipelines for apps with a space in the name

### DIFF
--- a/.bluemix/pipeline.yml
+++ b/.bluemix/pipeline.yml
@@ -36,28 +36,31 @@ stages:
     script: |
       #!/bin/bash
       # Push app
-      if ! cf app $CF_APP; then  
-        cf push $CF_APP
+      if ! cf app "$CF_APP"; then  
+        cf push "$CF_APP"
       else
-        OLD_CF_APP=${CF_APP}-OLD-$(date +"%s")
+        OLD_CF_APP="${CF_APP}-OLD-$(date +"%s")"
         rollback() {
           set +e  
-          if cf app $OLD_CF_APP; then
-            cf logs $CF_APP --recent
-            cf delete $CF_APP -f
-            cf rename $OLD_CF_APP $CF_APP
+          if cf app "$OLD_CF_APP"; then
+            cf logs "$CF_AP"P --recent
+            cf delete "$CF_APP" -f
+            cf rename "$OLD_CF_APP" "$CF_APP"
           fi
           exit 1
         }
         set -e
         trap rollback ERR
-        cf rename $CF_APP $OLD_CF_APP
-        cf push $CF_APP
-        cf delete $OLD_CF_APP -f
+        cf rename "$CF_APP" "$OLD_CF_APP"
+        cf push "$CF_APP"
+        cf delete "$OLD_CF_APP" -f
       fi
+
       # Export app name and URL for use in later Pipeline jobs
       export CF_APP_NAME="$CF_APP"
-      export APP_URL=http://$(cf app $CF_APP_NAME | grep -e urls: -e routes: | awk '{print $2}')
+      export APP_URL=http://$(cf app "$CF_APP_NAME" | grep -e urls: -e routes: | awk '{print $2}')
+
       # View logs
       #cf logs "${CF_APP}" --recent
+
       


### PR DESCRIPTION
If an app name was specified that contains a space, the pipeline deploy scripts will fail 100% of the time. The default value for the BYOC flow includes a space within an app name, so all CF toolchains for BYOC will fail by default. Wrapping the `$CF_APP` and `$OLD_CF_APP` values in quotes fixes this.