### PR TITLE
added quotes to fix pipelines for apps with a space in the name

### DIFF
--- a/.bluemix/pipeline.yml
+++ b/.bluemix/pipeline.yml
@@ -43,7 +43,7 @@ stages:
         rollback() {
           set +e  
           if cf app "$OLD_CF_APP"; then
-            cf logs "$CF_AP"P --recent
+            cf logs "$CF_APP" --recent
             cf delete "$CF_APP" -f
             cf rename "$OLD_CF_APP" "$CF_APP"
           fi

--- a/.bluemix/pipeline.yml
+++ b/.bluemix/pipeline.yml
@@ -35,6 +35,8 @@ stages:
       api_key: ${API_KEY}
     script: |
       #!/bin/bash
+      # Remove spaces and replace with "-". Spaces can cause bad CF deploy.
+      CF_APP="${CF_APP// /-}"
       # Push app
       if ! cf app $CF_APP; then  
         cf push $CF_APP

--- a/.bluemix/pipeline.yml
+++ b/.bluemix/pipeline.yml
@@ -35,27 +35,25 @@ stages:
       api_key: ${API_KEY}
     script: |
       #!/bin/bash
-      # Remove spaces and replace with "-". Spaces can cause bad CF deploy.
-      CF_APP="${CF_APP// /-}"
       # Push app
-      if ! cf app $CF_APP; then  
-        cf push $CF_APP
+      if ! cf app "$CF_APP"; then  
+        cf push "$CF_APP"
       else
-        OLD_CF_APP=${CF_APP}-OLD-$(date +"%s")
+        OLD_CF_APP="${CF_APP}-OLD-$(date +"%s")"
         rollback() {
           set +e  
-          if cf app $OLD_CF_APP; then
-            cf logs $CF_APP --recent
-            cf delete $CF_APP -f
-            cf rename $OLD_CF_APP $CF_APP
+          if cf app "$OLD_CF_APP"; then
+            cf logs "$CF_AP"P --recent
+            cf delete "$CF_APP" -f
+            cf rename "$OLD_CF_APP" "$CF_APP"
           fi
           exit 1
         }
         set -e
         trap rollback ERR
-        cf rename $CF_APP $OLD_CF_APP
-        cf push $CF_APP
-        cf delete $OLD_CF_APP -f
+        cf rename "$CF_APP" "$OLD_CF_APP"
+        cf push "$CF_APP"
+        cf delete "$OLD_CF_APP" -f
       fi
       # Export app name and URL for use in later Pipeline jobs
       export CF_APP_NAME="$CF_APP"


### PR DESCRIPTION
If an app name was specified that contains a space, the pipeline deploy scripts will fail 100% of the time. Wrapping the $CF_APP and $OLD_CF_APP values in quotes fixes this.