### PR TITLE
Revert "updating simple-toolchain-hosted for use with headless (#141)"

### DIFF
--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -33,9 +33,7 @@ template:
           '[' + $env.branch + ']('+ $env.repository + '/tree/' + $env.branch + ')' :
           '[master]('+ $env.repository + '/tree/master)'
 toolchain:
-  name: >
-    $env.toolchainName? '{{toolchainName}}' :
-    'simple-toolchain-{{timestamp}}'
+  name: 'simple-toolchain-{{timestamp}}'
   template:
     getting_started:
       $ref: "#/messages/template.gettingStarted"
@@ -46,12 +44,11 @@ services:
     parameters:
       repo_name: '{{toolchain.name}}'
       repo_url: >
-        $env.type === 'link' ? $env.app_repo :
-          $env.sourceZipUrl ? '{{sourceZipUrl}}' :
-            'https://github.com/open-toolchain/node-hello-world'
+        $env.type === 'link' ? 
+          $env.app_repo : 'https://github.com/open-toolchain/node-hello-world'
       source_repo_url: >
-        $env.type === 'fork' || $env.type === 'clone' ? $env.app_repo :
-          $env.sourceZipUrl ? '{{sourceZipUrl}}' : 'https://github.com/open-toolchain/node-hello-world'
+        $env.type === 'fork' || $env.type === 'clone' ? 
+          $env.app_repo : 'https://github.com/open-toolchain/node-hello-world'
       type: $env.type || 'clone'
       has_issues: true
       enable_traceability: true
@@ -78,12 +75,6 @@ services:
 form:
   pipeline:
     parameters:
-      prod-app-name: >
-        $env.prodAppName ?
-          '{{prodAppName}}' : '{{services.sample-repo.parameters.repo_name}}'
-      prod-space: '{{prodSpace}}'
-      prod-organization: '{{prodOrganization}}'
-      prod-region: '{{prodRegion}}'
-      api-key: '{{apiKey}}'
+      prod-app-name: '{{services.sample-repo.parameters.repo_name}}'
     schema:
       $ref: deploy.json


### PR DESCRIPTION
This reverts commit d520a6551e559098c5a980786c54b17e2f368275.

As it caused the setup/deploy page apiKey show/hide password icon to stop working.