### PR TITLE
again updating simple-toolchain-hosted for use with headless

### DIFF
--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -34,8 +34,8 @@ template:
           '[master]('+ $env.repository + '/tree/master)'
 toolchain:
   name: >
-    $env.toolchainName? '{{toolchainName}}' :
-    'simple-toolchain-{{timestamp}}'
+    $env.toolchainName ? '{{toolchainName}}' :
+      'simple-toolchain-{{timestamp}}'
   template:
     getting_started:
       $ref: "#/messages/template.gettingStarted"

--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -33,7 +33,9 @@ template:
           '[' + $env.branch + ']('+ $env.repository + '/tree/' + $env.branch + ')' :
           '[master]('+ $env.repository + '/tree/master)'
 toolchain:
-  name: 'simple-toolchain-{{timestamp}}'
+  name: >
+    $env.toolchainName? '{{toolchainName}}' :
+    'simple-toolchain-{{timestamp}}'
   template:
     getting_started:
       $ref: "#/messages/template.gettingStarted"
@@ -44,11 +46,12 @@ services:
     parameters:
       repo_name: '{{toolchain.name}}'
       repo_url: >
-        $env.type === 'link' ? 
-          $env.app_repo : 'https://github.com/open-toolchain/node-hello-world'
+        $env.type === 'link' ? $env.app_repo :
+          $env.sourceZipUrl ? '{{sourceZipUrl}}' :
+            'https://github.com/open-toolchain/node-hello-world'
       source_repo_url: >
-        $env.type === 'fork' || $env.type === 'clone' ? 
-          $env.app_repo : 'https://github.com/open-toolchain/node-hello-world'
+        $env.type === 'fork' || $env.type === 'clone' ? $env.app_repo :
+          $env.sourceZipUrl ? '{{sourceZipUrl}}' : 'https://github.com/open-toolchain/node-hello-world'
       type: $env.type || 'clone'
       has_issues: true
       enable_traceability: true
@@ -75,6 +78,12 @@ services:
 form:
   pipeline:
     parameters:
-      prod-app-name: '{{services.sample-repo.parameters.repo_name}}'
+      prod-app-name: >
+        $env.prodAppName ?
+          '{{prodAppName}}' : '{{services.sample-repo.parameters.repo_name}}'
+      prod-space: '{{prodSpace}}'
+      prod-organization: '{{prodOrganization}}'
+      prod-region: '{{prodRegion}}'
+      api-key: '{{apiKey}}'
     schema:
       $ref: deploy.json


### PR DESCRIPTION
where the headless toolchain creation api is as described in:

  Headless Toolchain Creation/Update using POST
  https://github.com/open-toolchain/sdk/wiki
    /Toolchain-Creation-page-parameters
      #headless-toolchain-creationupdate-using-post

This is a second attempt at the changes that were originally in the PR:
- updating simple-toolchain-hosted for use with headless
  https://github.com/open-toolchain/simple-toolchain-hosted/pull/141

where that first PR was reverted here:
 - Revert "updating simple-toolchain-hosted for use with headless (#141)"
    https://github.com/open-toolchain/simple-toolchain-hosted/pull/143

due to problems in the API Key edit box eyeball icon/button.
