### PR TITLE
tektonized templates should provide a manual trigger #13609

### DIFF
--- a/.bluemix/pipeline_tekton.yml
+++ b/.bluemix/pipeline_tekton.yml
@@ -23,6 +23,10 @@ triggers:
     service: ${SAMPLE_REPO}
     branch: master
     events: { "push": true }
+  - type: manual
+    name: manual-run
+    eventListener: manual-run
+    properties: []
 properties:
   - type: text
     name: cf-app

--- a/.pipeline/pipeline.yaml
+++ b/.pipeline/pipeline.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   params:
     - name: repository
-      description: the git repo containing source code. If empty, the repository url will be find from toolchain
+      description: the git repo containing source code. If empty, the repository url will be found from toolchain
       default: ""
     - name: branch
       description: the branch for the git repo

--- a/.pipeline/pipeline.yaml
+++ b/.pipeline/pipeline.yaml
@@ -31,6 +31,7 @@ spec:
         name: toolchain-extract-value
       params:
         - name: expression
+          # if a params.repository is given, it takes precedence
           value: '. as $toolchain | ["$(params.repository)"] | if .[0]=="" then $toolchain | .services[] | select(.toolchain_binding.name=="sample-repo") | .dashboard_url else .[0] end'
         - name: pipeline-debug
           value: $(params.pipeline-debug)  

--- a/.pipeline/pipeline.yaml
+++ b/.pipeline/pipeline.yaml
@@ -6,7 +6,8 @@ metadata:
 spec:
   params:
     - name: repository
-      description: the git repo
+      description: the git repo containing source code. If empty, the repository url will be find from toolchain
+      default: ""
     - name: branch
       description: the branch for the git repo
       default: "master"

--- a/.pipeline/pipeline.yaml
+++ b/.pipeline/pipeline.yaml
@@ -9,6 +9,7 @@ spec:
       description: the git repo
     - name: branch
       description: the branch for the git repo
+      default: "master"
     - name: revision
       description: the git revision/commit for the git repo
     - name: region
@@ -25,6 +26,14 @@ spec:
   workspaces:
     - name: pipeline-ws
   tasks:
+    - name: extract-repository-url
+      taskRef:
+        name: toolchain-extract-value
+      params:
+        - name: expression
+          value: '. as $toolchain | ["$(params.repository)"] | if .[0]=="" then $toolchain.services[] | .services[] | select(.toolchain_binding.name=="sample-repo") | .dashboard_url else .[0] end'
+        - name: pipeline-debug
+          value: $(params.pipeline-debug)  
     - name: clone-task
       taskRef:
         name: git-clone-repo
@@ -34,7 +43,7 @@ spec:
         - name: ibmcloud-apikey-secret-key
           value: "toolchain-apikey"
         - name: repository
-          value: $(params.repository)
+          value: $(tasks.extract-repository-url.results.extracted-value)
         - name: branch
           value: $(params.branch)
         - name: revision

--- a/.pipeline/pipeline.yaml
+++ b/.pipeline/pipeline.yaml
@@ -31,7 +31,7 @@ spec:
         name: toolchain-extract-value
       params:
         - name: expression
-          value: '. as $toolchain | ["$(params.repository)"] | if .[0]=="" then $toolchain.services[] | .services[] | select(.toolchain_binding.name=="sample-repo") | .dashboard_url else .[0] end'
+          value: '. as $toolchain | ["$(params.repository)"] | if .[0]=="" then $toolchain | .services[] | select(.toolchain_binding.name=="sample-repo") | .dashboard_url else .[0] end'
         - name: pipeline-debug
           value: $(params.pipeline-debug)  
     - name: clone-task


### PR DESCRIPTION
https://github.ibm.com/org-ids/roadmap/issues/13609

The intent of this PR is to be able to fetch the repository integrated in the toolchain that was set/created/linked as part as the template instanciation to create the  TC

If a given user set a Trigger Property to repository, the value of repository will be used instead - it takes precedence