### PR TITLE
Generate Tekton pipeline repo name based on toolchain name

### DIFF
--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -65,7 +65,8 @@ services:
     service_id: >
       $env.pipeline_type === 'tekton' ? $env.source_provider ? $env.source_provider : 'hostedgit' : ''
     parameters:
-      repo_name: "simple-toolchain-hosted-{{timestamp}}"
+      repo_name: >
+        $env.toolchainName ? '{{toolchainName}}-pipeline' : "simple-toolchain-hosted-{{timestamp}}"
       repo_url: >
         $env.repository
       source_repo_url: "https://github.com/open-toolchain/simple-toolchain-hosted"


### PR DESCRIPTION
Tested to be creatable via https://cloud.ibm.com/devops/setup/deploy?repository=https%3A%2F%2Fgithub.com%2Fopen-toolchain%2Fsimple-toolchain-hosted&env_id=ibm:yp:us-south&branch=pipeline-repo-name