### PR TITLE
new: additional build scan task

### DIFF
--- a/.pipeline/pipeline.yaml
+++ b/.pipeline/pipeline.yaml
@@ -27,6 +27,9 @@ spec:
     - name: ibmcloud-api
       description: IBM Cloud instance to target
       default: "https://cloud.ibm.com"
+    - name: custom-script
+      description: user-provided script
+      default: ""
   workspaces:
     - name: pipeline-ws
   tasks:
@@ -63,8 +66,20 @@ spec:
       workspaces:
         - name: output
           workspace: pipeline-ws
-    - name: rolling-deploy-task
+    - name: build
       runAfter: [clone-task]
+      workspaces:
+        - name: output
+          workspace: pipeline-ws
+      taskRef:
+        name: build-task
+      params:
+        - name: pipeline-debug
+          value: $(params.pipeline-debug)
+        - name: custom-script
+          value: $(params.custom-script)
+    - name: rolling-deploy-task
+      runAfter: [build]
       taskRef:
         name: cf-deploy-app
       params:

--- a/.south-pipeline/pipeline.yaml
+++ b/.south-pipeline/pipeline.yaml
@@ -33,6 +33,9 @@ spec:
     - name: scm-type
     - name: project-id
       default: ""
+    - name: custom-script
+      description: user-provided custom script
+      default: ""
   workspaces:
     - name: pipeline-ws
   tasks:
@@ -165,8 +168,20 @@ spec:
           value: $(params.scm-type)
         - name: project-id
           value: $(params.project-id)
-    - name: rolling-deploy-task
+    - name: build
       runAfter: [cra-discovery-scan]
+      workspaces:
+        - name: output
+          workspace: pipeline-ws
+      taskRef:
+        name: build-task
+      params:
+        - name: pipeline-debug
+          value: $(params.pipeline-debug)
+        - name: custom-script
+          value: $(params.custom-script)
+    - name: rolling-deploy-task
+      runAfter: [additional-build-scan]
       taskRef:
         name: cf-deploy-app
       params:

--- a/.south-pipeline/pipeline.yaml
+++ b/.south-pipeline/pipeline.yaml
@@ -33,6 +33,9 @@ spec:
     - name: scm-type
     - name: project-id
       default: ""
+    - name: custom-script
+      description: user-provided script
+      default: ""
   workspaces:
     - name: pipeline-ws
   tasks:
@@ -165,8 +168,20 @@ spec:
           value: $(params.scm-type)
         - name: project-id
           value: $(params.project-id)
-    - name: rolling-deploy-task
+    - name: build
       runAfter: [cra-discovery-scan]
+      workspaces:
+        - name: output
+          workspace: pipeline-ws
+      taskRef:
+        name: build-task
+      params:
+        - name: pipeline-debug
+          value: $(params.pipeline-debug)
+        - name: custom-script
+          value: $(params.custom-script)
+    - name: rolling-deploy-task
+      runAfter: [build]
       taskRef:
         name: cf-deploy-app
       params:


### PR DESCRIPTION
This update is for adding an additional task to the Tekton pipeline. It was discovered that there is a missing step required for Java starter kits, which is run in the Classic pipeline, but not in the Tekton pipeline.  

This PR is in reference to the following PR: https://github.com/open-toolchain/tekton-catalog/pull/212